### PR TITLE
change nopt builder names

### DIFF
--- a/backend/get_landed_prs.py
+++ b/backend/get_landed_prs.py
@@ -4,8 +4,8 @@ import requests, sqlite3, json, re, os
 from collections import defaultdict
 
 ONLY_OPT = ['opt']
-NO_VG = ['opt', 'nopt']
-ALL_OPTS = ['opt', 'nopt', 'opt-vg']
+NO_VG = ['opt', 'nopt-c', 'nopt-t']
+ALL_OPTS = ['opt', 'nopt-c', 'nopt-t', 'opt-vg']
 
 OS = {
     'linux': {


### PR DESCRIPTION
Modifies the builder list to account for split between nopt-compiler and nopt-testsuite, installed on the buildbot today.

(see https://github.com/mozilla/rust/issues/7425)
